### PR TITLE
loosen Compat requirement to 0.17

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.5
-Compat 0.18.0
+Compat 0.17.0


### PR DESCRIPTION
parametric type aliases not used here currently,
only new abstract type syntax