### PR TITLE
Fix MKL Pardiso support on Linux.

### DIFF
--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -121,7 +121,6 @@ function __init__()
                 get_nthreads[] = Libdl.dlsym(libmkl_core, "mkl_domain_get_max_threads")
             else
                 load_lib_fortran("libgomp", [7, 8])
-                Libdl.dlopen("libgomp", Libdl.RTLD_GLOBAL)
                 Libdl.dlopen(string(MKLROOT, "/lib/intel64/libmkl_core"), Libdl.RTLD_GLOBAL)
                 Libdl.dlopen(string(MKLROOT, "/lib/intel64/libmkl_gnu_thread"), Libdl.RTLD_GLOBAL)
                 libmkl_gd = Libdl.dlopen(string(MKLROOT, "/lib/intel64/libmkl_gf_lp64"), Libdl.RTLD_GLOBAL)


### PR DESCRIPTION
Pardiso.jl was trying to load libgomp twice, once in the way that works on 1.0 and once the old way. The current master of Pardiso.jl fails to load MKL Pardiso for me but works with the fix in this PR---only tested on my laptop running Ubuntu. The issue seems to be that [Line 123 of Pardiso.jl](https://github.com/JuliaSparse/Pardiso.jl/blob/637dfc2cf8607f36bc51434054176d401e1d4a99/src/Pardiso.jl#L123) was added in order to enable `dlopen` to find libgomp. As far as I can tell, [line 124](https://github.com/JuliaSparse/Pardiso.jl/blob/637dfc2cf8607f36bc51434054176d401e1d4a99/src/Pardiso.jl#L124) should then have been deleted but it hasn't been.