### PR TITLE
Allow StridedVecOrMat for RHS

### DIFF
--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -215,14 +215,14 @@ end
 
 
 function solve(ps::AbstractPardisoSolver, A::SparseMatrixCSC{Tv,Ti},
-               B::VecOrMat{Tv}, T::Symbol=:N) where {Ti, Tv <: PardisoNumTypes}
+               B::StridedVecOrMat{Tv}, T::Symbol=:N) where {Ti, Tv <: PardisoNumTypes}
   X = copy(B)
   solve!(ps, X, A, B, T)
   return X
 end
 
-function solve!(ps::AbstractPardisoSolver, X::VecOrMat{Tv},
-                A::SparseMatrixCSC{Tv,Ti}, B::VecOrMat{Tv},
+function solve!(ps::AbstractPardisoSolver, X::StridedVecOrMat{Tv},
+                A::SparseMatrixCSC{Tv,Ti}, B::StridedVecOrMat{Tv},
                 T::Symbol=:N) where {Ti, Tv <: PardisoNumTypes}
 
     pardisoinit(ps)
@@ -286,8 +286,8 @@ function solve!(ps::AbstractPardisoSolver, X::VecOrMat{Tv},
     return X
 end
 
-function pardiso(ps::AbstractPardisoSolver, X::VecOrMat{Tv}, A::SparseMatrixCSC{Tv,Ti},
-                 B::VecOrMat{Tv}) where {Ti, Tv <: PardisoNumTypes}
+function pardiso(ps::AbstractPardisoSolver, X::StridedVecOrMat{Tv}, A::SparseMatrixCSC{Tv,Ti},
+                 B::StridedVecOrMat{Tv}) where {Ti, Tv <: PardisoNumTypes}
     if length(X) != 0
         dim_check(X, A, B)
     end
@@ -316,7 +316,7 @@ function pardiso(ps::AbstractPardisoSolver, X::VecOrMat{Tv}, A::SparseMatrixCSC{
 end
 
 pardiso(ps::AbstractPardisoSolver) = ccall_pardiso(ps, Int32(0), Float64[], Int32[], Int32[], Int32(0), Float64[], Float64[])
-function pardiso(ps::AbstractPardisoSolver, A::SparseMatrixCSC{Tv,Ti}, B::VecOrMat{Tv}) where {Ti, Tv <: PardisoNumTypes}
+function pardiso(ps::AbstractPardisoSolver, A::SparseMatrixCSC{Tv,Ti}, B::StridedVecOrMat{Tv}) where {Ti, Tv <: PardisoNumTypes}
     pardiso(ps, Tv[], A, B)
 end
 
@@ -325,6 +325,8 @@ function dim_check(X, A, B)
                                                          "RHS has size as $(size(B)).")))
     size(A, 1) == size(B, 1) || throw(DimensionMismatch(string("matrix has $(size(A,1)) ",
                                                                "rows, RHS has $(size(B,1)) rows.")))
+    size(B, 1) == stride(B, 2) || throw(DimensionMismatch(
+                                            string("Only memory-contiguous RHS supported")))
 end
 
 end # module

--- a/src/mkl_pardiso.jl
+++ b/src/mkl_pardiso.jl
@@ -80,7 +80,7 @@ end
 
 
 function ccall_pardiso(ps::MKLPardisoSolver, N, AA::Vector{Tv}, IA, JA,
-                       NRHS, B::VecOrMat{Tv}, X::VecOrMat{Tv}) where {Tv}
+                       NRHS, B::StridedVecOrMat{Tv}, X::StridedVecOrMat{Tv}) where {Tv}
     ERR = Ref{Int32}(0)
     ccall(mkl_pardiso_f[], Cvoid,
           (Ptr{Int}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32},

--- a/src/project_pardiso.jl
+++ b/src/project_pardiso.jl
@@ -102,7 +102,7 @@ end
 
 
 @inline function ccall_pardiso(ps::PardisoSolver, N::Int32, AA::Vector{Tv},
-                                   IA, JA, NRHS::Int32, B::VecOrMat{Tv}, X::VecOrMat{Tv}) where {Tv}
+                                   IA, JA, NRHS::Int32, B::StridedVecOrMat{Tv}, X::StridedVecOrMat{Tv}) where {Tv}
     ERR = Ref{Int32}(0)
     ccall(pardiso_f[], Cvoid,
           (Ptr{Int}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32},
@@ -120,7 +120,7 @@ end
 
 # Different checks
 function printstats(ps::PardisoSolver, A::SparseMatrixCSC{Tv, Ti},
-                    B::VecOrMat{Tv}) where {Ti,Tv <: PardisoNumTypes}
+                    B::StridedVecOrMat{Tv}) where {Ti,Tv <: PardisoNumTypes}
     N = Int32(size(A, 2))
     AA = A.nzval
     IA = convert(Vector{Int32}, A.colptr)
@@ -165,7 +165,7 @@ function checkmatrix(ps::PardisoSolver, A::SparseMatrixCSC{Tv, Ti}) where {Ti,Tv
     return
 end
 
-function checkvec(ps, B::VecOrMat{Tv}) where {Tv <: PardisoNumTypes}
+function checkvec(ps, B::StridedVecOrMat{Tv}) where {Tv <: PardisoNumTypes}
     N = Int32(size(B, 1))
     NRHS = Int32(size(B, 2))
     ERR = Int32[0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,28 +32,29 @@ for pardiso_type in psolvers
         end
 
         A1 = sparse(rand(T, 10,10))
-        B = rand(T, 10, 2)
-        X = similar(B)
+        for B in (rand(T, 10, 2), view(rand(T, 10, 4), 1:10, 2:3))
+            X = similar(B)
 
-        # Test unsymmetric, herm indef, herm posdef and symmetric
-        for A in SparseMatrixCSC[A1, A1 + A1', A1'A1, transpose(A1) + A1]
-            solve!(ps, X, A, B)
-            @test X ≈ A\B
+            # Test unsymmetric, herm indef, herm posdef and symmetric
+            for A in SparseMatrixCSC[A1, A1 + A1', A1'A1, transpose(A1) + A1]
+                solve!(ps, X, A, B)
+                @test X ≈ A\Matrix(B)
 
-            X = solve(ps, A, B)
-            @test X ≈ A\B
+                X = solve(ps, A, B)
+                @test X ≈ A\Matrix(B)
 
-            solve!(ps, X, A, B, :C)
-            @test X ≈ A'\B
+                solve!(ps, X, A, B, :C)
+                @test X ≈ A'\Matrix(B)
 
-            X = solve(ps, A, B, :C)
-            @test X ≈ A'\B
+                X = solve(ps, A, B, :C)
+                @test X ≈ A'\Matrix(B)
 
-            solve!(ps, X, A, B, :T)
-            @test X ≈ copy(transpose(A))\B
+                solve!(ps, X, A, B, :T)
+                @test X ≈ copy(transpose(A))\Matrix(B)
 
-            X = solve(ps, A, B, :T)
-            @test X ≈ copy(transpose(A))\B
+                X = solve(ps, A, B, :T)
+                @test X ≈ copy(transpose(A))\Matrix(B)
+            end
         end
     end
 end


### PR DESCRIPTION
Addresses #11

This allows the right hand side `B` in `A * X == B` to be a `StridedVecOrMat`, which includes `Vector` or `Matrix` views (`SubArray`s). A restriction applies: a `B::SubArray` should be contiguous in memory for Pardiso to handle it correctly. If it is not, a `DimensionMismatch` error is thrown.