### PR TITLE
Added support for gcc v6 to the Pardiso MKL solver

### DIFF
--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -120,7 +120,7 @@ function __init__()
                 set_nthreads[] = Libdl.dlsym(libmkl_core, "mkl_domain_set_num_threads")
                 get_nthreads[] = Libdl.dlsym(libmkl_core, "mkl_domain_get_max_threads")
             else
-                load_lib_fortran("libgomp", [7, 8])
+                load_lib_fortran("libgomp", [6, 7, 8])
                 Libdl.dlopen(string(MKLROOT, "/lib/intel64/libmkl_core"), Libdl.RTLD_GLOBAL)
                 Libdl.dlopen(string(MKLROOT, "/lib/intel64/libmkl_gnu_thread"), Libdl.RTLD_GLOBAL)
                 libmkl_gd = Libdl.dlopen(string(MKLROOT, "/lib/intel64/libmkl_gf_lp64"), Libdl.RTLD_GLOBAL)


### PR DESCRIPTION
Tests pass on my Debian laptop for gcc 6.3.0 (installed via apt-get) and MKL 2019.1.144