### PR TITLE
Fixes for self-installed MKL from intel oneAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,21 @@ library.
 
 ### MKL PARDISO
 
-By default Julia, will automatically install a suitable MKL for your platform.
+By default Julia, will automatically install a suitable MKL for your platform by loading `MKL_jll.jl`.
 Note that if you use a mac you will need to pin `MKL_jll` to version 2023.
 
-If you rather use a self installed MKL follow these instructions:
+If you instead use a self installed MKL, follow these instructions:
 
-* Set the `MKLROOT` environment variable. See the [MKL getting started
-  manual](https://software.intel.com/en-us/articles/intel-mkl-103-getting-started)
+* Set the `MKLROOT` environment variable. See the [MKL set environment variables
+  manual](https://www.intel.com/content/www/us/en/docs/onemkl/developer-guide-linux/2024-0/scripts-to-set-environment-variables.html)
   for a thorough guide how to set this variable correctly, typically done by
-  executing something like `source /opt/intel/mkl/bin/mklvars.sh intel64` or
+  executing something like `source /opt/intel/oneapi/setvars.sh intel64` or
   running `"C:\Program Files (x86)\IntelSWTools\compilers_and_libraries\windows\mkl\bin\mklvars.bat" intel64`
-* Run `Pkg.build("Pardiso")`
+* Run `Pkg.build("Pardiso", verbose=true)`
 * Run `Pardiso.show_build_log()` to see the build log for additional
   information.
-* Note that the `MKLROOT` environment variable must be set whenever using the library.
+* Note that the `MKLROOT` environment variable must be set, and `LD_LIBRARY_PATH` must contain `$MKLROOT/lib`  
+  whenever using the library.
 
 ### PARDISO 6.0
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -68,10 +68,10 @@ println("\nMKL Pardiso")
 println("=============")
 function find_mklparadiso()
     if haskey(ENV, "MKLROOT")
-        println("found MKLROOT environment varaible, enabling local MKL")
+        println("found MKLROOT environment variable, enabling local MKL")
         return true
     end
-    println("did not find MKLROOT environment variable, using provided MKL")
+    println("did not find MKLROOT environment variable, using MKL_jll")
     return false
 end
 

--- a/src/mkl_pardiso.jl
+++ b/src/mkl_pardiso.jl
@@ -13,7 +13,7 @@ mutable struct MKLPardisoSolver <: AbstractPardisoSolver
 end
 
 function MKLPardisoSolver()
-    if !( LOCAL_MKL_FOUND || MKL_jll.is_available())
+    if !(LOCAL_MKL_FOUND || MKL_jll.is_available())
         error("MKL is not available no this platform")
     end
     pt = zeros(Int, 64)

--- a/src/mkl_pardiso.jl
+++ b/src/mkl_pardiso.jl
@@ -13,7 +13,7 @@ mutable struct MKLPardisoSolver <: AbstractPardisoSolver
 end
 
 function MKLPardisoSolver()
-    if !MKL_jll.is_available()
+    if !( LOCAL_MKL_FOUND || MKL_jll.is_available())
         error("MKL is not available no this platform")
     end
     pt = zeros(Int, 64)

--- a/src/mkl_pardiso.jl
+++ b/src/mkl_pardiso.jl
@@ -13,8 +13,8 @@ mutable struct MKLPardisoSolver <: AbstractPardisoSolver
 end
 
 function MKLPardisoSolver()
-    if !(LOCAL_MKL_FOUND || MKL_jll.is_available())
-        error("MKL is not available no this platform")
+    if !(mkl_is_available())
+        error("MKL is not available")
     end
     pt = zeros(Int, 64)
     iparm = zeros(MklInt, 64)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,11 @@
 ENV["OMP_NUM_THREADS"] = 2
 
+
 using Pkg
 if Sys.isapple()
     Pkg.add(name="MKL_jll"; version = "2023")
 end
+
 
 using Test
 using Pardiso
@@ -14,7 +16,7 @@ using LinearAlgebra
 Random.seed!(1234)
 
 available_solvers = empty([Pardiso.AbstractPardisoSolver])
-if Pardiso.MKL_jll.is_available()
+if Pardiso.mkl_is_available()
     push!(available_solvers, MKLPardisoSolver)
 else
     @warn "Not testing MKL Pardiso solver"
@@ -71,7 +73,7 @@ for solver in available_solvers
     example_hermitian_psd(solver)
 end
 
-if Pardiso.MKL_jll.is_available()
+if Pardiso.mkl_is_available()
     if Sys.CPU_THREADS >= 4
         @testset "procs" begin
             ps = MKLPardisoSolver()


### PR DESCRIPTION
* introduces Pardiso.mkl_is_available() for use in runtests.jl
* test load mkl in __init__ (like pardiso)
* some link updates, hint at LD_LIBRARY_PATH