### PR TITLE
Exposing single precision support from MKL

### DIFF
--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -64,7 +64,7 @@ end
 Base.showerror(io::IO, e::Union{PardisoException,PardisoPosDefException}) = print(io, e.info);
 
 
-const PardisoNumTypes = Union{Float64,ComplexF64}
+const PardisoNumTypes = Union{Float32, ComplexF32, Float64, ComplexF64}
 
 abstract type AbstractPardisoSolver end
 
@@ -173,7 +173,7 @@ function __init__()
     end
 end
 include("enums.jl")
-include("project_pardiso.jl")
+include("panua_pardiso.jl")
 include("mkl_pardiso.jl")
 
 # Getters and setters
@@ -218,9 +218,9 @@ end
 
 function solve(ps::AbstractPardisoSolver, A::SparseMatrixCSC{Tv,Ti},
                B::StridedVecOrMat{Tv}, T::Symbol=:N) where {Ti, Tv <: PardisoNumTypes}
-  X = copy(B)
-  solve!(ps, X, A, B, T)
-  return X
+    X = copy(B)
+    solve!(ps, X, A, B, T)
+    return X
 end
 
 function fix_iparm!(ps::AbstractPardisoSolver, T::Symbol)
@@ -244,6 +244,7 @@ end
 function solve!(ps::AbstractPardisoSolver, X::StridedVecOrMat{Tv},
                 A::SparseMatrixCSC{Tv,Ti}, B::StridedVecOrMat{Tv},
                 T::Symbol=:N) where {Ti, Tv <: PardisoNumTypes}
+    LinearAlgebra.checksquare(A)
     set_phase!(ps, ANALYSIS_NUM_FACT_SOLVE_REFINE)
 
     # This is the heuristics for choosing what matrix type to use
@@ -253,9 +254,10 @@ function solve!(ps::AbstractPardisoSolver, X::StridedVecOrMat{Tv},
     # - If complex and symmetric, solve with symmetric complex solver
     # - Else solve as unsymmetric.
     if ishermitian(A)
-        eltype(A) == Float64 ? set_matrixtype!(ps, REAL_SYM_POSDEF) : set_matrixtype!(ps, COMPLEX_HERM_POSDEF)
+        eltype(A) <: Union{Float32, Float64} ? set_matrixtype!(ps, REAL_SYM_POSDEF) : set_matrixtype!(ps, COMPLEX_HERM_POSDEF)
         pardisoinit(ps)
         fix_iparm!(ps, T)
+        eltype(A) <: Union{Float32, ComplexF32} ? set_iparm!(ps, 28, 1) : nothing
         try
             pardiso(ps, X, get_matrix(ps, A, T), B)
         catch e
@@ -265,20 +267,23 @@ function solve!(ps::AbstractPardisoSolver, X::StridedVecOrMat{Tv},
             if !isa(e, PardisoPosDefException)
                 rethrow()
             end
-            eltype(A) == Float64 ? set_matrixtype!(ps, REAL_SYM_INDEF) : set_matrixtype!(ps, COMPLEX_HERM_INDEF)
+            eltype(A) <: Union{Float32, Float64} ? set_matrixtype!(ps, REAL_SYM_INDEF) : set_matrixtype!(ps, COMPLEX_HERM_INDEF)
             pardisoinit(ps)
             fix_iparm!(ps, T)
+            eltype(A) <: Union{Float32, ComplexF32} ? set_iparm!(ps, 28, 1) : nothing
             pardiso(ps, X, get_matrix(ps, A, T), B)
         end
     elseif issymmetric(A)
         set_matrixtype!(ps, COMPLEX_SYM)
         pardisoinit(ps)
         fix_iparm!(ps, T)
+        eltype(A) <: Union{Float32, ComplexF32} ? set_iparm!(ps, 28, 1) : nothing
         pardiso(ps, X, get_matrix(ps, A, T), B)
     else
-        eltype(A) == Float64 ? set_matrixtype!(ps, REAL_NONSYM) : set_matrixtype!(ps, COMPLEX_NONSYM)
+        eltype(A) <: Union{Float32, Float64} ? set_matrixtype!(ps, REAL_NONSYM) : set_matrixtype!(ps, COMPLEX_NONSYM)
         pardisoinit(ps)
         fix_iparm!(ps, T)
+        eltype(A) <: Union{Float32, ComplexF32} ? set_iparm!(ps, 28, 1) : nothing
         pardiso(ps, X, get_matrix(ps, A, T), B)
     end
 
@@ -435,6 +440,7 @@ function pardisogetschur(ps::AbstractPardisoSolver)
 end
 
 function dim_check(X, A, B)
+    LinearAlgebra.checksquare(A)
     size(X) == size(B) || throw(DimensionMismatch(string("solution has $(size(X)), ",
                                                          "RHS has size as $(size(B)).")))
     size(A, 1) == size(B, 1) || throw(DimensionMismatch(string("matrix has $(size(A,1)) ",

--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -338,6 +338,11 @@ function pardiso(ps::AbstractPardisoSolver, X::StridedVecOrMat{Tv}, A::SparseMat
                                     "has a complex matrix type set: $(get_matrixtype(ps))")))
     end
 
+    if Tv <: Union{Float32, ComplexF32} && typeof(ps) <: MKLPardisoSolver && ps.iparm[28] != 1
+        throw(ErrorException(string("input matrix is Float32/ComplexF32 while MKLPardisoSolver ",
+                                    "have iparm[28]=$(ps.iparm[28]) rather than 1.")))
+    end
+
     N = size(A, 2)
     
     resize!(ps.perm, size(B, 1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,11 +31,14 @@ end
 
 println("Testing ", available_solvers)
 
+supported_eltypes(ps::PardisoSolver) = (Float64, ComplexF64)
+supported_eltypes(ps::MKLPardisoSolver) = (Float32, ComplexF32, Float64, ComplexF64)
+
 # Test solver + for real and complex data
 @testset "solving" begin
 for pardiso_type in available_solvers
     ps = pardiso_type()
-    for T in (Float64, ComplexF64)
+    for T in supported_eltypes(ps)
         A1 = sparse(rand(T, 10,10))
         for B in (rand(T, 10, 2), view(rand(T, 10, 4), 1:10, 2:3))
             X = similar(B)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,7 +39,8 @@ supported_eltypes(ps::MKLPardisoSolver) = (Float32, ComplexF32, Float64, Complex
 for pardiso_type in available_solvers
     ps = pardiso_type()
     for T in supported_eltypes(ps)
-        # Previous versions of SparseArrays do not support Float32
+        # Older vesions SparseArrays do not support Float32/ComplexF64.
+        # As such the reference solution will always be computed in Float64/ComplexF64
         S = T <: Real ? Float64 : ComplexF64 
         A1 = sparse(rand(T, 10,10))
         for B in (rand(T, 10, 2), view(rand(T, 10, 4), 1:10, 2:3))
@@ -47,22 +48,22 @@ for pardiso_type in available_solvers
             # Test unsymmetric, herm indef, herm posdef and symmetric
             for A in SparseMatrixCSC[A1, A1 + A1', A1'A1, transpose(A1) + A1]
                 solve!(ps, X, A, B)
-                @test X ≈ convert.(S,A)\convert.(S,Matrix(B))
+                @test X ≈ convert.(T,convert.(S,A)\convert.(S,Matrix(B)))
 
                 X = solve(ps, A, B)
-                @test X ≈ convert.(S,A)\convert.(S,Matrix(B))
+                @test X ≈ convert.(T,convert.(S,A)\convert.(S,Matrix(B)))
 
                 solve!(ps, X, A, B, :C)
-                @test X ≈ convert.(S,A)'\convert.(S,Matrix(B))
+                @test X ≈ convert.(T,convert.(S,A)'\convert.(S,Matrix(B)))
 
                 X = solve(ps, A, B, :C)
-                @test X ≈ convert.(S,A)'\convert.(S,Matrix(B))
+                @test X ≈ convert.(T,convert.(S,A)'\convert.(S,Matrix(B)))
 
                 solve!(ps, X, A, B, :T)
-                @test X ≈ copy(transpose(convert.(S,A)))\convert.(S,Matrix(B))
+                @test X ≈ convert.(T,copy(transpose(convert.(S,A)))\convert.(S,Matrix(B)))
 
                 X = solve(ps, A, B, :T)
-                @test X ≈ copy(transpose(convert.(S,A)))\convert.(S,Matrix(B))
+                @test X ≈ convert.(T,copy(transpose(convert.(S,A)))\convert.(S,Matrix(B)))
             end
         end
     end


### PR DESCRIPTION
 - Exposing single precision support from MKL. #107 
 - Changing name of file from "project_pardiso.jl" to "panua_pardiso.jl".
 - Adding check for square matrix. #102 
 - Changing error referencing "pardiso.lic" to "panua.lic" #106 
 - Store internal Vector{Int32} versions of `colptr` and `rowval` when using Panua in order to avoid memory usage in the case of the sparsity pattern not changing.