### PR TITLE
Follow matrix type branching from MKL Pardiso docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,8 @@ julia = "1.6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "Printf", "Pkg"]
+test = ["StableRNGs", "Test", "Random", "Printf", "Pkg"]

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The matrix type can be explicitly set with `set_matrixtype!(ps, key)` where the 
 
 | enum                 | integer | Matrix type                               |
 |--------------------- |---------| ----------------------------------------  |
-| REAL_SYM             | 1       | real and structurally symmetric           |
+| REAL_STRUCT_SYM      | 1       | real and structurally symmetric           |
 | REAL_SYM_POSDEF      | 2       | real and symmetric positive definite      |
 | REAL_SYM_INDEF       | -2      | real and symmetric indefinite             |
 | COMPLEX_STRUCT_SYM   | 3       | complex and structurally symmetric        |

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The matrix type can be explicitly set with `set_matrixtype!(ps, key)` where the 
 
 | enum                 | integer | Matrix type                               |
 |--------------------- |---------| ----------------------------------------  |
-| REAL_STRUCT_SYM      | 1       | real and structurally symmetric           |
+| REAL_SYM             | 1       | real and structurally symmetric           |
 | REAL_SYM_POSDEF      | 2       | real and symmetric positive definite      |
 | REAL_SYM_INDEF       | -2      | real and symmetric indefinite             |
 | COMPLEX_STRUCT_SYM   | 3       | complex and structurally symmetric        |

--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -318,7 +318,7 @@ function _is_hermsym(A::SparseMatrixCSC, check::Function)
     return true
 end
 
-isstructurallysymmetric(A::SparseMatrixCSC) = _is_hermsym(A, Returns(true))
+isstructurallysymmetric(A::SparseMatrixCSC) = _is_hermsym(A, (x,y) -> true)
 
 function solve!(ps::AbstractPardisoSolver, X::StridedVecOrMat{Tv},
                 A::SparseMatrixCSC{Tv,Ti}, B::StridedVecOrMat{Tv},

--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -355,7 +355,7 @@ function solve!(ps::AbstractPardisoSolver, X::StridedVecOrMat{Tv},
             end
         else
             if isstructurallysymmetric(A)
-                set_matrixtype!(ps, REAL_STRUCT_SYM)
+                set_matrixtype!(ps, REAL_SYM)
             else
                 set_matrixtype!(ps, REAL_NONSYM)
             end

--- a/src/enums.jl
+++ b/src/enums.jl
@@ -1,6 +1,6 @@
 # Matrix type
 @enum(MatrixType::Int32,
-    REAL_STRUCT_SYM     = 1,
+    REAL_SYM            = 1,
     REAL_SYM_POSDEF     = 2,
     REAL_SYM_INDEF      = -2,
     COMPLEX_STRUCT_SYM  = 3,
@@ -11,14 +11,14 @@
     COMPLEX_NONSYM      = 13,
 )
 
-Base.isreal(v::MatrixType) = v in (REAL_STRUCT_SYM, REAL_SYM_POSDEF, REAL_SYM_INDEF, REAL_NONSYM)
+Base.isreal(v::MatrixType) = v in (REAL_SYM, REAL_SYM_POSDEF, REAL_SYM_INDEF, REAL_NONSYM)
 LinearAlgebra.issymmetric(v::MatrixType) = v in (REAL_SYM_POSDEF, REAL_SYM_INDEF,
                                         COMPLEX_HERM_POSDEF, COMPLEX_HERM_INDEF, COMPLEX_SYM)
 LinearAlgebra.ishermitian(v::MatrixType) = v in (REAL_SYM_POSDEF, COMPLEX_HERM_POSDEF, COMPLEX_HERM_INDEF)
 isposornegdef(v::MatrixType) = v in (REAL_SYM_POSDEF, REAL_SYM_INDEF, COMPLEX_HERM_POSDEF, COMPLEX_HERM_INDEF)
 
 const MATRIX_STRING = Dict{MatrixType, String}(
-    REAL_STRUCT_SYM => "Real structurally symmetric",
+    REAL_SYM => "Real structurally symmetric",
     REAL_SYM_POSDEF => "Real symmetric positive definite",
     REAL_SYM_INDEF => "Real symmetric indefinite",
     COMPLEX_STRUCT_SYM => "Complex structurally symmetric",
@@ -29,7 +29,7 @@ const MATRIX_STRING = Dict{MatrixType, String}(
     COMPLEX_NONSYM  => "Complex nonsymmetric"
 )
 
-const REAL_MATRIX_TYPES = [REAL_STRUCT_SYM, REAL_SYM_POSDEF, REAL_SYM_INDEF, REAL_NONSYM]
+const REAL_MATRIX_TYPES = [REAL_SYM, REAL_SYM_POSDEF, REAL_SYM_INDEF, REAL_NONSYM]
 const COMPLEX_MATRIX_TYPES = [COMPLEX_STRUCT_SYM, COMPLEX_HERM_POSDEF, COMPLEX_HERM_INDEF, COMPLEX_NONSYM, COMPLEX_SYM]
 
 # Messages

--- a/src/enums.jl
+++ b/src/enums.jl
@@ -1,6 +1,6 @@
 # Matrix type
 @enum(MatrixType::Int32,
-    REAL_SYM            = 1,
+    REAL_STRUCT_SYM     = 1,
     REAL_SYM_POSDEF     = 2,
     REAL_SYM_INDEF      = -2,
     COMPLEX_STRUCT_SYM  = 3,
@@ -11,14 +11,14 @@
     COMPLEX_NONSYM      = 13,
 )
 
-Base.isreal(v::MatrixType) = v in (REAL_SYM, REAL_SYM_POSDEF, REAL_SYM_INDEF, REAL_NONSYM)
-LinearAlgebra.issymmetric(v::MatrixType) = v in (REAL_SYM, REAL_SYM_POSDEF, REAL_SYM_INDEF, COMPLEX_STRUCT_SYM,
+Base.isreal(v::MatrixType) = v in (REAL_STRUCT_SYM, REAL_SYM_POSDEF, REAL_SYM_INDEF, REAL_NONSYM)
+LinearAlgebra.issymmetric(v::MatrixType) = v in (REAL_SYM_POSDEF, REAL_SYM_INDEF,
                                         COMPLEX_HERM_POSDEF, COMPLEX_HERM_INDEF, COMPLEX_SYM)
 LinearAlgebra.ishermitian(v::MatrixType) = v in (REAL_SYM_POSDEF, COMPLEX_HERM_POSDEF, COMPLEX_HERM_INDEF)
 isposornegdef(v::MatrixType) = v in (REAL_SYM_POSDEF, REAL_SYM_INDEF, COMPLEX_HERM_POSDEF, COMPLEX_HERM_INDEF)
 
 const MATRIX_STRING = Dict{MatrixType, String}(
-    REAL_SYM => "Real structurally symmetric",
+    REAL_STRUCT_SYM => "Real structurally symmetric",
     REAL_SYM_POSDEF => "Real symmetric positive definite",
     REAL_SYM_INDEF => "Real symmetric indefinite",
     COMPLEX_STRUCT_SYM => "Complex structurally symmetric",
@@ -29,8 +29,8 @@ const MATRIX_STRING = Dict{MatrixType, String}(
     COMPLEX_NONSYM  => "Complex nonsymmetric"
 )
 
-const REAL_MATRIX_TYPES = [REAL_SYM, REAL_SYM_POSDEF, REAL_SYM_INDEF, REAL_NONSYM]
-const COMPLEX_MATRIX_TYPES = [COMPLEX_STRUCT_SYM, COMPLEX_HERM_POSDEF, COMPLEX_HERM_INDEF, COMPLEX_NONSYM]
+const REAL_MATRIX_TYPES = [REAL_STRUCT_SYM, REAL_SYM_POSDEF, REAL_SYM_INDEF, REAL_NONSYM]
+const COMPLEX_MATRIX_TYPES = [COMPLEX_STRUCT_SYM, COMPLEX_HERM_POSDEF, COMPLEX_HERM_INDEF, COMPLEX_NONSYM, COMPLEX_SYM]
 
 # Messages
 @enum(MessageLevel::Int32,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,8 +187,8 @@ for pardiso_type in available_solvers
     set_iparm!(ps, 13, 100)
     @test get_iparm(ps, 13) == 100
 
-    set_matrixtype!(ps, Pardiso.REAL_SYM)
-    @test get_matrixtype(ps) == Pardiso.REAL_SYM
+    set_matrixtype!(ps, Pardiso.REAL_STRUCT_SYM)
+    @test get_matrixtype(ps) == Pardiso.REAL_STRUCT_SYM
 
     set_phase!(ps, Pardiso.ANALYSIS_NUM_FACT)
     @test get_phase(ps) == Pardiso.ANALYSIS_NUM_FACT

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,11 +9,10 @@ end
 
 using Test
 using Pardiso
+using StableRNGs
 using Random
 using SparseArrays
 using LinearAlgebra
-
-Random.seed!(1234)
 
 available_solvers = empty([Pardiso.AbstractPardisoSolver])
 if Pardiso.mkl_is_available()
@@ -27,6 +26,8 @@ else
     @warn "Not testing panua Pardiso solver"
 end
 
+const rng = StableRNG(1)
+
 @show Pardiso.MklInt
 
 println("Testing ", available_solvers)
@@ -38,9 +39,10 @@ supported_eltypes(ps::MKLPardisoSolver) = (Float32, ComplexF32, Float64, Complex
 @testset "solving" begin
 for pardiso_type in available_solvers
     ps = pardiso_type()
+    Random.seed!(rng, 1234)
     for T in supported_eltypes(ps)
-        A1 = sparse(rand(T, 10,10))
-        for B in (rand(T, 10, 2), view(rand(T, 10, 4), 1:10, 2:3))
+        A1 = sparse(rand(rng, T, 10,10))
+        for B in (rand(rng, T, 10, 2), view(rand(rng, T, 10, 4), 1:10, 2:3))
             X = similar(B)
             # Test unsymmetric, herm indef, herm posdef and symmetric
             for A in SparseMatrixCSC[A1, A1 + A1', A1'A1 + I, transpose(A1) + A1]
@@ -91,6 +93,7 @@ end
 
 if Pardiso.PARDISO_LOADED[]
 @testset "schur" begin
+    Random.seed!(rng, 1234)
     # reproduce example from Pardiso website
     include("schur_matrix_def.jl")
     @test norm(real(D) - real(C)*rA⁻¹*real(B) - s) < 1e-10*(8)^2
@@ -108,11 +111,11 @@ if Pardiso.PARDISO_LOADED[]
             set_matrixtype!(ps, 13)
         end
         for j ∈ 1:100
-            A = 5I + sprand(T,m,m,p)
+            A = 5I + sprand(rng,T,m,m,p)
             A⁻¹ = inv(Matrix(A))
-            B = sprand(T,m,n,p)
-            C = sprand(T,n,m,p)
-            D = 5I + sprand(T,n,n,p)
+            B = sprand(rng,T,m,n,p)
+            C = sprand(rng,T,n,m,p)
+            D = 5I + sprand(rng,T,n,n,p)
             M = [A B; C D]
 
             # test integer block specification
@@ -137,13 +140,14 @@ end # testset
 end
 
 @testset "error checks" begin
+Random.seed!(rng, 1234)
 for pardiso_type in available_solvers
 
     ps = pardiso_type()
 
-    A = sparse(rand(10,10))
-    B = rand(10, 2)
-    X = rand(10, 2)
+    A = sparse(rand(rng,10,10))
+    B = rand(rng, 10, 2)
+    X = rand(rng, 10, 2)
 
     if pardiso_type == PardisoSolver
         printstats(ps, A, B)
@@ -160,7 +164,7 @@ for pardiso_type in available_solvers
     X = zeros(12, 2)
     @test_throws DimensionMismatch solve!(ps,X, A, B)
 
-    B = rand(12, 2)
+    B = rand(rng, 12, 2)
     @test_throws DimensionMismatch solve(ps, A, B)
 end
 end # testset
@@ -201,9 +205,10 @@ for pardiso_type in available_solvers
 end
 
 @testset "pardiso" begin
+    Random.seed!(rng, 1234)
     for pardiso_type in available_solvers
-        A = sparse(rand(2,2) + im * rand(2,2))
-        b = rand(2)          + im * rand(2)
+        A = sparse(rand(rng,2,2) + im * rand(rng,2,2))
+        b = rand(rng,2)          + im * rand(rng,2)
         ps = pardiso_type()
         set_matrixtype!(ps, Pardiso.COMPLEX_NONSYM)
         x = Pardiso.solve(ps, A, b);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,8 +190,8 @@ for pardiso_type in available_solvers
     set_iparm!(ps, 13, 100)
     @test get_iparm(ps, 13) == 100
 
-    set_matrixtype!(ps, Pardiso.REAL_STRUCT_SYM)
-    @test get_matrixtype(ps) == Pardiso.REAL_STRUCT_SYM
+    set_matrixtype!(ps, Pardiso.REAL_SYM)
+    @test get_matrixtype(ps) == Pardiso.REAL_SYM
 
     set_phase!(ps, Pardiso.ANALYSIS_NUM_FACT)
     @test get_phase(ps) == Pardiso.ANALYSIS_NUM_FACT


### PR DESCRIPTION
Replace the current heuristics with the matrix type branching in this figure from the [MKL Pardiso docs](https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-c/2023-0/onemkl-pardiso-parallel-direct-sparse-solver-iface.html#SSR_FIG8-1):

![image](https://github.com/user-attachments/assets/dd405c12-0e16-4d86-932f-9af4a6fa88d4)

This seems to cover more cases, and in particular, to branch correctly into the structurally symmetric cases.

Context: This is a bit of a shot in the dark, coming from #113 and #112. I'm no Pardiso expert so not even sure if this helps but it passed the tests locally on my Mac and so was curious if breaks things on other platforms. Hopefully this PR will put this to the test!