### PR TITLE
add panua license check

### DIFF
--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -130,7 +130,11 @@ function panua_is_licensed()
             PARDISO_LICENSED[] = true
             return true
         catch e
-            return false
+            if isa(e, ErrorException) && occursin(r"(?i)licen[cs]e|unlicensed|not licensed", e.msg)
+                return false
+            else
+                rethrow(e)
+            end
         end
     end
 end

--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -112,9 +112,31 @@ const pardiso_chkvec = Ref{Ptr}()
 const pardiso_chkvec_z = Ref{Ptr}()
 const pardiso_get_schur_f = Ref{Ptr}()
 const PARDISO_LOADED = Ref(false)
+const PARDISO_LICENSED = Ref(false)
 
-panua_is_available() = PARDISO_LOADED[]
+function panua_is_licensed()
 
+    if !PARDISO_LOADED[]
+        return false
+    elseif PARDISO_LICENSED[]
+        return true
+    end
+    redirect_stdout(devnull) do
+        try
+            ps = PardisoSolver(;loadchecks = false)
+            pardisoinit(ps)   #errors if unlicensed
+            PARDISO_LICENSED[] = true
+            return true
+        catch e
+            return false
+        end
+    end
+end
+
+panua_is_loaded() = PARDISO_LOADED[]
+panua_is_available() = panua_is_loaded() && panua_is_licensed()
+
+    
 function __init__()
     global MKL_LOAD_FAILED
     if LOCAL_MKL_FOUND

--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -51,7 +51,8 @@ export solve, solve!
 export get_matrix
 export schur_complement, pardisogetschur
 export fix_iparm!
-export  mkl_is_available, panua_is_available
+export mkl_is_available, panua_is_available
+export panua_is_loaded, panua_is_licensed
 
 struct PardisoException <: Exception
     info::String

--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -52,7 +52,8 @@ export get_matrix
 export schur_complement, pardisogetschur
 export fix_iparm!
 export mkl_is_available, panua_is_available
-export panua_is_loaded, panua_is_licensed
+
+VERSION >= v"1.11.0-DEV.469" && eval(Meta.parse("public panua_is_loaded, panua_is_licensed"))
 
 struct PardisoException <: Exception
     info::String

--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -135,7 +135,16 @@ function panua_is_licensed()
             else
                 rethrow(e)
             end
+    try
+        ps = PardisoSolver(;loadchecks = false)
+        # Suppress unwanted output from pardisoinit, which prints license info to stdout
+        redirect_stdout(devnull) do
+            pardisoinit(ps)   # errors if unlicensed
         end
+        PARDISO_LICENSED[] = true
+        return true
+    catch e
+        return false
     end
 end
 

--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -123,28 +123,20 @@ function panua_is_licensed()
     elseif PARDISO_LICENSED[]
         return true
     end
+    # Suppress unwanted output from pardisoinit, which prints license info to stdout
     redirect_stdout(devnull) do
         try
             ps = PardisoSolver(;loadchecks = false)
-            pardisoinit(ps)   #errors if unlicensed
+            pardisoinit(ps)   # errors if unlicensed
             PARDISO_LICENSED[] = true
             return true
         catch e
-            if isa(e, ErrorException) && occursin(r"(?i)licen[cs]e|unlicensed|not licensed", e.msg)
+            if isa(e, PardisoException)
                 return false
             else
                 rethrow(e)
             end
-    try
-        ps = PardisoSolver(;loadchecks = false)
-        # Suppress unwanted output from pardisoinit, which prints license info to stdout
-        redirect_stdout(devnull) do
-            pardisoinit(ps)   # errors if unlicensed
         end
-        PARDISO_LICENSED[] = true
-        return true
-    catch e
-        return false
     end
 end
 

--- a/src/panua_pardiso.jl
+++ b/src/panua_pardiso.jl
@@ -13,9 +13,13 @@ mutable struct PardisoSolver <: AbstractPardisoSolver
     rowval::Vector{Int32}
 end
 
-function PardisoSolver()
-    if !panua_is_available()
-      error("Panua pardiso library was not loaded")
+function PardisoSolver(; loadchecks::Bool = true)
+    if loadchecks
+        if !panua_is_loaded()
+        error("Panua pardiso library was not loaded")
+        elseif !panua_is_licensed()
+        error("Panua pardiso library requires license")
+        end
     end
 
     pt = zeros(Int, 64)


### PR DESCRIPTION
Adds separate `panua_is_loaded` and `panua_is_licensed` functions.

This fixes an issue where `panua_is_available()` reports `true` when the library exists and is loaded but is unlicensed.

As far as I can see in the Panua documentation the only way to check for a valid license is to allocate memory for a solver and then call `pardisoinit` on it.   This is slightly awkward because `PardisoSolver` itself should check if the library is loaded (and, ideally, licensed) before creating and initializing a solver.

I have therefore implemented this by having `panua_is_loaded` call the `PardisoSolver` constructor directly but with availability checks skipped, and then saving to the constant  ref `PARDISO_LICENSED` if successful.