### PR TITLE
Use 64-bit Pardiso when BLAS vendor is LBT

### DIFF
--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -30,7 +30,7 @@ MKL_LOAD_FAILED = false
 
 mkl_is_available() = (LOCAL_MKL_FOUND || MKL_jll.is_available()) && !MKL_LOAD_FAILED
 
-if LinearAlgebra.BLAS.vendor() === :mkl && LinearAlgebra.BlasInt == Int64
+if LinearAlgebra.BLAS.vendor() in (:mkl, :lbt) && LinearAlgebra.BlasInt == Int64
     const MklInt = Int64
     const PARDISO_FUNC = :pardiso_64
 else

--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -30,7 +30,15 @@ MKL_LOAD_FAILED = false
 
 mkl_is_available() = (LOCAL_MKL_FOUND || MKL_jll.is_available()) && !MKL_LOAD_FAILED
 
-if all(occursin("mkl", basename(x.libname)) for x in BLAS.get_config().loaded_libs) && LinearAlgebra.BlasInt == Int64
+# Copied from RecursiveFactorization.jl
+const blaslib = if VERSION ≥ v"1.7.0-beta2"
+    config = BLAS.get_config().loaded_libs
+    occursin("mkl_rt", config[1].libname) ? :MKL : :OpenBLAS
+else
+    BLAS.vendor() === :mkl ? :MKL : :OpenBLAS
+end
+
+if blaslib == :MKL && LinearAlgebra.BlasInt == Int64
     const MklInt = Int64
     const PARDISO_FUNC = :pardiso_64
 else

--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -30,7 +30,7 @@ MKL_LOAD_FAILED = false
 
 mkl_is_available() = (LOCAL_MKL_FOUND || MKL_jll.is_available()) && !MKL_LOAD_FAILED
 
-if LinearAlgebra.BLAS.vendor() in (:mkl, :lbt) && LinearAlgebra.BlasInt == Int64
+if all(occursin("mkl", basename(x.libname)) for x in BLAS.get_config().loaded_libs) && LinearAlgebra.BlasInt == Int64
     const MklInt = Int64
     const PARDISO_FUNC = :pardiso_64
 else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ end
 
 const rng = StableRNG(1)
 
-@show blaslib
+@show Pardiso.blaslib
 @show LinearAlgebra.BlasInt
 @show Pardiso.MklInt
 @show Pardiso.PARDISO_FUNC

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,10 @@ end
 
 const rng = StableRNG(1)
 
+@show LinearAlgebra.BLAS.vendor()
+@show LinearAlgebra.BlasInt
 @show Pardiso.MklInt
+@show Pardiso.PARDISO_FUNC
 
 println("Testing ", available_solvers)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,8 +28,7 @@ end
 
 const rng = StableRNG(1)
 
-@show BLAS.get_config()
-@show BLAS.vendor()
+@show blaslib
 @show LinearAlgebra.BlasInt
 @show Pardiso.MklInt
 @show Pardiso.PARDISO_FUNC

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,8 @@ end
 
 const rng = StableRNG(1)
 
-@show LinearAlgebra.BLAS.vendor()
+@show BLAS.get_config()
+@show BLAS.vendor()
 @show LinearAlgebra.BlasInt
 @show Pardiso.MklInt
 @show Pardiso.PARDISO_FUNC


### PR DESCRIPTION
Attempt at fixing #110.

Note I don't really understand the internals, just trying this out and hopefully the CI tests will let us know if that was not worth it.