### PR TITLE
Add missing function _isnotzero

### DIFF
--- a/src/Pardiso.jl
+++ b/src/Pardiso.jl
@@ -283,6 +283,9 @@ end
 
 # Copied from SparseArrays.jl but with a tweak
 # to check symmetry of the sparsity pattern
+@inline _isnotzero(x) = iszero(x) !== true # like `!iszero(x)`, but handles `x::Missing`
+@inline _isnotzero(x::Number) = !iszero(x)
+@inline _isnotzero(x::AbstractArray) = !iszero(x)
 function _is_hermsym(A::SparseMatrixCSC, check::Function)
     m, n = size(A)
     if m != n; return false; end


### PR DESCRIPTION
Fix UndefVarError when solving generic linear system.

Somwhat-minimal working example:

```julia
using MatrixDepot # v1.0.13
using Pardiso # v1.1.0
using StableRNGs #v1.0.3

matrix = "Sandia/mult_dcop_01"
A = matrixdepot(matrix)
x_ref = randn(StableRNG(42), size(A, 2))
b = A * x_ref

ps = MKLPardisoSolver()
x = solve(ps, A, b)
```